### PR TITLE
Pass :redix config to Redix

### DIFF
--- a/lib/redix_pool/worker.ex
+++ b/lib/redix_pool/worker.ex
@@ -30,7 +30,8 @@ defmodule RedixPool.Worker do
 
   defp connect do
     redis_url = Config.get(:redis_url, @redis_url)
-    {:ok, conn} = Redix.start_link(redis_url)
+    redix_config = Config.get(:redix, %{})
+    {:ok, conn} = Redix.start_link(redis_url, redix_config)
     conn
   end
 end


### PR DESCRIPTION
Allow users to specify the Redix configuration they wish to use.